### PR TITLE
MNT Require graphql 4.x-dev for some builds in the matrix

### DIFF
--- a/config/jobs/cwp-recipe-cms-fixed-behat.yml
+++ b/config/jobs/cwp-recipe-cms-fixed-behat.yml
@@ -6,3 +6,10 @@ jobs:
         - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE"
+        - REQUIRE_RECIPE_TESTING=^1
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/cwp-recipe-cms-fixed.yml
+++ b/config/jobs/cwp-recipe-cms-fixed.yml
@@ -24,11 +24,13 @@ jobs:
         - DB=MYSQL
         - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
         - COMPOSER_INSTALL_ARG=--ignore-platform-reqs
   allow_failures:
     - php: 8.0

--- a/config/jobs/cwp-recipe-cms-range-behat.yml
+++ b/config/jobs/cwp-recipe-cms-range-behat.yml
@@ -6,3 +6,10 @@ jobs:
         - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE 2.6.x-dev"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE 2.7.x-dev"
+        - REQUIRE_RECIPE_TESTING=^1
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/cwp-recipe-cms-range.yml
+++ b/config/jobs/cwp-recipe-cms-range.yml
@@ -24,11 +24,13 @@ jobs:
         - DB=MYSQL
         - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE 2.x-dev"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE 2.x-dev"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
         - COMPOSER_INSTALL_ARG=--ignore-platform-reqs
   allow_failures:
     - php: 8.0

--- a/config/jobs/cwp-self-fixed-behat.yml
+++ b/config/jobs/cwp-self-fixed-behat.yml
@@ -5,3 +5,9 @@ jobs:
         - DB=MYSQL
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - REQUIRE_RECIPE_TESTING=^1
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/cwp-self-fixed.yml
+++ b/config/jobs/cwp-self-fixed.yml
@@ -20,10 +20,12 @@ jobs:
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
         - COMPOSER_INSTALL_ARG=--ignore-platform-reqs
   allow_failures:
     - php: 8.0

--- a/config/jobs/cwp-self-range-behat.yml
+++ b/config/jobs/cwp-self-range-behat.yml
@@ -5,3 +5,9 @@ jobs:
         - DB=MYSQL
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - REQUIRE_RECIPE_TESTING=^1
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/cwp-self-range.yml
+++ b/config/jobs/cwp-self-range.yml
@@ -20,10 +20,12 @@ jobs:
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
         - COMPOSER_INSTALL_ARG=--ignore-platform-reqs
   allow_failures:
     - php: 8.0

--- a/config/jobs/installer-fixed-behat.yml
+++ b/config/jobs/installer-fixed-behat.yml
@@ -6,3 +6,10 @@ jobs:
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
+        - REQUIRE_RECIPE_TESTING=^1
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/installer-fixed.yml
+++ b/config/jobs/installer-fixed.yml
@@ -24,9 +24,11 @@ jobs:
         - DB=MYSQL
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
         - COMPOSER_INSTALL_ARG=--ignore-platform-reqs

--- a/config/jobs/installer-range-behat.yml
+++ b/config/jobs/installer-range-behat.yml
@@ -6,3 +6,10 @@ jobs:
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE 4.6.x-dev"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="$REQUIRE_RECIPE 4.6.x-dev"
+        - REQUIRE_RECIPE_TESTING=^1
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/installer-range.yml
+++ b/config/jobs/installer-range.yml
@@ -24,9 +24,11 @@ jobs:
         - DB=MYSQL
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE 4.x-dev"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE 4.x-dev"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
         - COMPOSER_INSTALL_ARG=--ignore-platform-reqs

--- a/config/jobs/recipe-core-fixed-behat.yml
+++ b/config/jobs/recipe-core-fixed-behat.yml
@@ -6,3 +6,10 @@ jobs:
         - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE"
+        - REQUIRE_RECIPE_TESTING=^1
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/recipe-core-fixed.yml
+++ b/config/jobs/recipe-core-fixed.yml
@@ -24,9 +24,11 @@ jobs:
         - DB=MYSQL
         - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
         - COMPOSER_INSTALL_ARG=--ignore-platform-reqs

--- a/config/jobs/recipe-core-range-behat.yml
+++ b/config/jobs/recipe-core-range-behat.yml
@@ -6,3 +6,10 @@ jobs:
         - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE 4.6.x-dev"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE 4.6.x-dev"
+        - REQUIRE_RECIPE_TESTING=^1
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/recipe-core-range.yml
+++ b/config/jobs/recipe-core-range.yml
@@ -24,9 +24,11 @@ jobs:
         - DB=MYSQL
         - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE 4.x-dev"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE 4.x-dev"
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
         - COMPOSER_INSTALL_ARG=--ignore-platform-reqs

--- a/config/jobs/self-fixed-behat.yml
+++ b/config/jobs/self-fixed-behat.yml
@@ -5,3 +5,9 @@ jobs:
         - DB=MYSQL
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - REQUIRE_RECIPE_TESTING=^1
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/self-fixed.yml
+++ b/config/jobs/self-fixed.yml
@@ -20,8 +20,10 @@ jobs:
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
         - COMPOSER_INSTALL_ARG=--ignore-platform-reqs

--- a/config/jobs/self-range-behat.yml
+++ b/config/jobs/self-range-behat.yml
@@ -5,3 +5,9 @@ jobs:
         - DB=MYSQL
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - REQUIRE_RECIPE_TESTING=^1
+        - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/self-range.yml
+++ b/config/jobs/self-range.yml
@@ -20,8 +20,10 @@ jobs:
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"
         - COMPOSER_INSTALL_ARG=--ignore-platform-reqs


### PR DESCRIPTION
Implementation of https://github.com/silverstripeltd/product-issues/issues/333

Notes:
- I've used `^3@dev || 4.x-dev` instead of `4.x-dev` so that any requirements with a hard requirement of "silverstripe/graphql: ^3" instead of "silverstripe/graphql: ^3 || 4.x-dev" can still install and not break the build - though they WON'T be getting graphql 4 tested against them for the time being
- Will install graphql 4.x-dev on recipe 4.7.x-dev jobs in 'jobs-fixed' provisions for next-patch branches e.g. asset-admin 1.7.x-dev.  GraphQL 4 is compatible with recipe 4.7.x-dev so this is fine
- I haven't defined graphql 3 on the other jobs in the matrix because it'll default to that, and it's good to use the version version defined in composer requirements e.g. 3.4.x-dev
