### PR TITLE
MNT Use graphql 3 for the first behat job

### DIFF
--- a/config/jobs/cwp-recipe-cms-fixed-behat.yml
+++ b/config/jobs/cwp-recipe-cms-fixed-behat.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
     - php: 7.3
       env:
         - DB=MYSQL

--- a/config/jobs/cwp-recipe-cms-range-behat.yml
+++ b/config/jobs/cwp-recipe-cms-range-behat.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE 2.6.x-dev"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
     - php: 7.3
       env:
         - DB=MYSQL

--- a/config/jobs/cwp-self-fixed-behat.yml
+++ b/config/jobs/cwp-self-fixed-behat.yml
@@ -6,6 +6,7 @@ jobs:
         - DB=MYSQL
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
     - php: 7.3
       env:
         - DB=MYSQL

--- a/config/jobs/cwp-self-range-behat.yml
+++ b/config/jobs/cwp-self-range-behat.yml
@@ -6,6 +6,7 @@ jobs:
         - DB=MYSQL
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
     - php: 7.3
       env:
         - DB=MYSQL

--- a/config/jobs/installer-fixed-behat.yml
+++ b/config/jobs/installer-fixed-behat.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
     - php: 7.3
       env:
         - DB=MYSQL

--- a/config/jobs/installer-range-behat.yml
+++ b/config/jobs/installer-range-behat.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE 4.6.x-dev"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
     - php: 7.3
       env:
         - DB=MYSQL

--- a/config/jobs/recipe-core-fixed-behat.yml
+++ b/config/jobs/recipe-core-fixed-behat.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
     - php: 7.3
       env:
         - DB=MYSQL

--- a/config/jobs/recipe-core-range-behat.yml
+++ b/config/jobs/recipe-core-range-behat.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE 4.6.x-dev"
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
     - php: 7.3
       env:
         - DB=MYSQL

--- a/config/jobs/self-fixed-behat.yml
+++ b/config/jobs/self-fixed-behat.yml
@@ -6,6 +6,7 @@ jobs:
         - DB=MYSQL
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
     - php: 7.3
       env:
         - DB=MYSQL

--- a/config/jobs/self-range-behat.yml
+++ b/config/jobs/self-range-behat.yml
@@ -6,6 +6,7 @@ jobs:
         - DB=MYSQL
         - REQUIRE_RECIPE_TESTING=^1
         - BEHAT_TEST=1
+        - REQUIRE_GRAPHQL="^3@dev"
     - php: 7.3
       env:
         - DB=MYSQL


### PR DESCRIPTION
Previously 1.x branches as versioned-admin weren't using graphql 3 for the first behat job, instead they'd use graphql 4 which is what the second behat job is supposed to do.  This change makes the first job explicitly use graphql 3