### PR TITLE
NEW: Add optional phpstan execution to PHPCS_TEST

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -123,6 +123,9 @@ script:
   # PHPCS
   - if [[ $PHPCS_TEST && -f phpcs.xml.dist ]]; then vendor/bin/phpcs; fi
 
+  # PHPSTAN
+  - if [[ $PHPSTAN_TEST && -f phpstan.neon.dist ]]; then vendor/bin/phpstan analyse; fi
+
   # NPM
   - if [[ $NPM_TEST ]]; then git diff-files --quiet -w --relative=client; fi
   - if [[ $NPM_TEST ]]; then git diff --name-status --relative=client; fi

--- a/config/jobs/cwp-recipe-cms-fixed.yml
+++ b/config/jobs/cwp-recipe-cms-fixed.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE"
         - PHPUNIT_TEST=1
         - PHPCS_TEST=1
+        - PHPSTAN_TEST=1
     - php: 7.2
       env:
         - DB=MYSQL

--- a/config/jobs/cwp-recipe-cms-range.yml
+++ b/config/jobs/cwp-recipe-cms-range.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_CWP_CWP_RECIPE_CMS="$REQUIRE_RECIPE 2.5.x-dev"
         - PHPUNIT_TEST=1
         - PHPCS_TEST=1
+        - PHPSTAN_TEST=1
     - php: 7.2
       env:
         - DB=MYSQL

--- a/config/jobs/cwp-self-fixed.yml
+++ b/config/jobs/cwp-self-fixed.yml
@@ -6,6 +6,7 @@ jobs:
         - DB=MYSQL
         - PHPUNIT_TEST=1
         - PHPCS_TEST=1
+        - PHPSTAN_TEST=1
     - php: 7.2
       env:
         - DB=MYSQL

--- a/config/jobs/installer-fixed.yml
+++ b/config/jobs/installer-fixed.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
         - PHPUNIT_TEST=1
         - PHPCS_TEST=1
+        - PHPSTAN_TEST=1
     - php: 7.2
       env:
         - DB=PGSQL

--- a/config/jobs/installer-range.yml
+++ b/config/jobs/installer-range.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE 4.5.x-dev"
         - PHPUNIT_TEST=1
         - PHPCS_TEST=1
+        - PHPSTAN_TEST=1
     - php: 7.2
       env:
         - DB=PGSQL

--- a/config/jobs/recipe-core-fixed.yml
+++ b/config/jobs/recipe-core-fixed.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE"
         - PHPUNIT_TEST=1
         - PHPCS_TEST=1
+        - PHPSTAN_TEST=1
     - php: 7.2
       env:
         - DB=PGSQL

--- a/config/jobs/recipe-core-range.yml
+++ b/config/jobs/recipe-core-range.yml
@@ -7,6 +7,7 @@ jobs:
         - REQUIRE_RECIPE_CORE="$REQUIRE_RECIPE 4.5.x-dev"
         - PHPUNIT_TEST=1
         - PHPCS_TEST=1
+        - PHPSTAN_TEST=1
     - php: 7.2
       env:
         - DB=PGSQL

--- a/config/jobs/self-fixed.yml
+++ b/config/jobs/self-fixed.yml
@@ -6,6 +6,7 @@ jobs:
         - DB=MYSQL
         - PHPUNIT_TEST=1
         - PHPCS_TEST=1
+        - PHPSTAN_TEST=1
     - php: 7.2
       env:
         - DB=PGSQL

--- a/config/jobs/self-range.yml
+++ b/config/jobs/self-range.yml
@@ -6,6 +6,7 @@ jobs:
         - DB=MYSQL
         - PHPUNIT_TEST=1
         - PHPCS_TEST=1
+        - PHPSTAN_TEST=1
     - php: 7.2
       env:
         - DB=PGSQL


### PR DESCRIPTION
PHPStan is a static analyser that may be of use to some repositories.
Notably, I've got a small, passing PHPStan level 1 PR to submit to
framework.

This will include a phpstan call in the PHPCS_TEST build, if
phpstan.neon.dist exists.

I've opted not to split it out as a separate build var to reduce the
number of separate builds. This is essentially another form of
sophisticated linting, hence putting it with phpcs.