### PR TITLE
ENH Automatically derive COMPOSER_ROOT_VERSION

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -47,6 +47,12 @@ before_script:
   # Install chromium and chromedriver
   - if [[ $BEHAT_TEST ]]; then sudo apt-get install -y chromium-browser chromium-chromedriver; fi
 
+  # COMPOSER_ROOT_VERSION (move to section below when this works)
+  echo '====='
+  echo 'TRAVIS_BRANCH:'
+  echo "$TRAVIS_BRANCH"
+  echo '*****'
+
   # COMPOSER
   # install $COMPOSER_VERSION if defined, otherwise use Composer v1 with PHP <= 7.3, Composer v2 for >= 7.3
   - if [ $COMPOSER_VERSION ]; then composer self-update "$COMPOSER_VERSION"; elif [ $(php -r 'echo (int) version_compare(phpversion(), "7.3.0", "<=");') = "1" ]; then composer self-update 1.9.3; else composer self-update; fi


### PR DESCRIPTION
This is the PR from silverstripe account

Using non-standard branch name because the travis shared @ syntax for branch name seems to be fussy about slashes in the branch name

PR from ccs account silverstripe/silverstripe-campaign-admin#202