### PR TITLE
MNT Use latest codecov binary

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -165,13 +165,12 @@ before_script:
 
   # codecov
   # https://about.codecov.io/blog/introducing-codecovs-new-uploader/
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then curl -Os https://uploader.codecov.io/latest/codecov-linux; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then curl -Os https://uploader.codecov.io/latest/codecov-linux.SHA256SUM; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then curl -Os https://uploader.codecov.io/latest/codecov-linux.SHA256SUM.sig; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then gpg --verify codecov-linux.SHA256SUM.sig codecov-linux.SHA256SUM; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then shasum -a 256 -c codecov-linux.SHA256SUM; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then chmod +x codecov-linux; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then curl -Os https://uploader.codecov.io/latest/linux/codecov; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then if [[ $(shasum -a 256 -c codecov.SHA256SUM 2>&1) =~ OK ]] && [[ $(gpgv codecov.SHA256SUM.sig codecov.SHA256SUM 2>&1) =~ "Good signature" ]]; then CODECOV_VERIFIED=1; fi; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then chmod +x codecov; fi
 
 script:
   # PHPUNIT
@@ -203,8 +202,8 @@ script:
 
 after_success:
   # codecov
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then ./codecov-linux -f coverage.xml; fi
-  
+  - if [[ $PHPUNIT_COVERAGE_TEST ]] && [[ $CODECOV_VERIFIED ]]; then ./codecov -f coverage.xml; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]] && ! [[ $CODECOV_VERIFIED ]]; then echo "codecov verification was INVALID!" && false; fi
 
 after_failure:
   # BEHAT


### PR DESCRIPTION
Codecov isn't currently working, possibly it's been down for a while

https://app.travis-ci.com/github/silverstripe/silverstripe-html5/jobs/560655797#L1221

The docs say we should be using
`./codecov -t ${CODECOV_TOKEN}`

I'm not sure if the `-t` is required at this stage since it looks as though it's already being added based on the redacted token in the travis build.  We can look to add it in if things are are still not working after this pull-request.
