### PR TITLE
MNT Require recipe-testing ^2

### DIFF
--- a/config/jobs/installer-fixed-behat.yml
+++ b/config/jobs/installer-fixed-behat.yml
@@ -5,13 +5,13 @@ jobs:
       env:
         - DB=MYSQL
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
-        - REQUIRE_RECIPE_TESTING=^1
+        - REQUIRE_RECIPE_TESTING=^2
         - BEHAT_TEST=1
         - REQUIRE_GRAPHQL="^3@dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
-        - REQUIRE_RECIPE_TESTING=^1
+        - REQUIRE_RECIPE_TESTING=^2
         - BEHAT_TEST=1
         - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/installer-range-behat.yml
+++ b/config/jobs/installer-range-behat.yml
@@ -5,13 +5,13 @@ jobs:
       env:
         - DB=MYSQL
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE 4.x-dev"
-        - REQUIRE_RECIPE_TESTING=^1
+        - REQUIRE_RECIPE_TESTING=^2
         - BEHAT_TEST=1
         - REQUIRE_GRAPHQL="^3@dev"
     - php: 8.0
       env:
         - DB=MYSQL
         - REQUIRE_INSTALLER="$REQUIRE_RECIPE 4.x-dev"
-        - REQUIRE_RECIPE_TESTING=^1
+        - REQUIRE_RECIPE_TESTING=^2
         - BEHAT_TEST=1
         - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/self-fixed-behat.yml
+++ b/config/jobs/self-fixed-behat.yml
@@ -4,12 +4,12 @@ jobs:
     - php: 7.4
       env:
         - DB=MYSQL
-        - REQUIRE_RECIPE_TESTING=^1
+        - REQUIRE_RECIPE_TESTING=^2
         - BEHAT_TEST=1
         - REQUIRE_GRAPHQL="^3@dev"
     - php: 8.0
       env:
         - DB=MYSQL
-        - REQUIRE_RECIPE_TESTING=^1
+        - REQUIRE_RECIPE_TESTING=^2
         - BEHAT_TEST=1
         - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"

--- a/config/jobs/self-range-behat.yml
+++ b/config/jobs/self-range-behat.yml
@@ -4,12 +4,12 @@ jobs:
     - php: 7.4
       env:
         - DB=MYSQL
-        - REQUIRE_RECIPE_TESTING=^1
+        - REQUIRE_RECIPE_TESTING=^2
         - BEHAT_TEST=1
         - REQUIRE_GRAPHQL="^3@dev"
     - php: 8.0
       env:
         - DB=MYSQL
-        - REQUIRE_RECIPE_TESTING=^1
+        - REQUIRE_RECIPE_TESTING=^2
         - BEHAT_TEST=1
         - REQUIRE_GRAPHQL="^3@dev || 4.x-dev"


### PR DESCRIPTION
This *might* be what's causing https://app.travis-ci.com/github/silverstripe/silverstripe-totp-authenticator/jobs/563967194 to install an old version of webautn-autnenticator (4.0.0-beta1), causing the build to break

In either cause, we should only be using recipe-testing ^2 at this point