### PR TITLE
Ignore dependabot branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+before_script:
+  - gem install travis --no-document
+  # dismiss travis prompt about autocomplete
+  - echo "y" | travis --version
+script:
+  # validate all the yml files in config dir using travis cli tool
+  - find ./config/ -type f -name '*.yml' | xargs -L 1 travis lint -x

--- a/config/base.yml
+++ b/config/base.yml
@@ -4,6 +4,11 @@ os: linux
 
 dist: bionic
 
+# Ignore branches created by dependabot - these will be tested in the PR build
+branches:
+  except:
+    - /^dependabot\/.*/
+
 # Always install services for postgres + behat because "services"
 # does not "merge" correctly so this cannot be dynamic
 services:


### PR DESCRIPTION
At the moment, when @dependabot opens a PR we get two travis builds, one for the branch on the repo and one for the PR opened.

The PR builds (tend to) pass, where as the branches themselves fail because composer doesn't know what the base version is.

There is no need for these two builds and the failing build prevents automated merging.

This PR attempts to resolve that problem by ignoring all dependabot branches from all our shared configs

Also adds some linting to the config files in CI