### PR TITLE
Use composer install to install dependencies

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -127,7 +127,7 @@ before_script:
   - if [[ $(composer validate 2>&1 | tr '\n' ' ') =~ ' is valid' ]]; then cat composer.json; fi
     
   # Install with --prefer-source to ensure that admin javascript (which has export-ignore in .gitattributes) is installed so that NPM_TEST works properly
-  - composer update --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile $COMPOSER_INSTALL_ARG
+  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile $COMPOSER_INSTALL_ARG
   - composer show
 
   # Remove vendor unit tests files that were installed because of the use of --prefer-source

--- a/config/base.yml
+++ b/config/base.yml
@@ -127,7 +127,7 @@ before_script:
   - if [[ $(composer validate 2>&1 | tr '\n' ' ') =~ ' is valid' ]]; then cat composer.json; fi
     
   # Install with --prefer-source to ensure that admin javascript (which has export-ignore in .gitattributes) is installed so that NPM_TEST works properly
-  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile $COMPOSER_INSTALL_ARG
+  - composer install --prefer-source --no-interaction --no-progress --optimize-autoloader --verbose --profile $COMPOSER_INSTALL_ARG
   - composer show
 
   # Remove vendor unit tests files that were installed because of the use of --prefer-source


### PR DESCRIPTION
This change uses `composer install` instead of `composer update` to install dependencies.

The point of the `composer.lock` file is to allow reproducible dependency installs across environments/projects. To use the `update` command during CI means that we get non-reproducible results and that we ship an untested lock file with our projects.

Not only this, but the use of `update` instead of `install` is having quite profound impacts on CI build times. Looking at the [mfa module](https://app.travis-ci.com/github/silverstripe/silverstripe-mfa/builds/207190654) as an example, installation times have gone from 25 seconds to 3.5 minutes when switching from `install` to `update`.

Unless there's some undocumented reason as to why `update` is preferred to `install`, this should be changed