### PR TITLE
FIX Use composer update for prefer-lowest

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -127,7 +127,9 @@ before_script:
   - if [[ $(composer validate 2>&1 | tr '\n' ' ') =~ ' is valid' ]]; then cat composer.json; fi
     
   # Install with --prefer-source to ensure that admin javascript (which has export-ignore in .gitattributes) is installed so that NPM_TEST works properly
-  - composer install --prefer-source --no-interaction --no-progress --optimize-autoloader --verbose --profile $COMPOSER_INSTALL_ARG
+  # $COMPOSER_INSTALL_ARG is sometimes --prefer-lowest which is only supported by `composer update`, not `composer install`
+  # Modules do not have composer.lock files, so `composer update` is the same speed as `composer install`
+  - composer update --prefer-source --no-interaction --no-progress --optimize-autoloader --verbose --profile $COMPOSER_INSTALL_ARG
   - composer show
 
   # Remove vendor unit tests files that were installed because of the use of --prefer-source


### PR DESCRIPTION
Fixes this https://app.travis-ci.com/github/silverstripe/silverstripe-framework/jobs/567064712

Happened after we optimised to use `composer install` instead of `composer update` https://github.com/silverstripe/silverstripe-travis-shared/pull/35

